### PR TITLE
removed mysql-0 in db-host

### DIFF
--- a/1.0.0/RC1/operator.yaml
+++ b/1.0.0/RC1/operator.yaml
@@ -2441,7 +2441,7 @@ spec:
         - name: maya-io
           args:
             - "--db-host"
-            - "mysql-0.mysql.variablename.svc.cluster.local"
+            - "mysql.variablename.svc.cluster.local"
             - "--db-user"
             - "maya"
             - "--db-pass"


### PR DESCRIPTION
Removed mysql-0 in db-host from maya-io deployment.
Signed-off-by: Prabhat Kumar Thakur prabhat.thakur@mayadata.io