### PR TITLE
make max member count configurable

### DIFF
--- a/1.7.0/director/README.md
+++ b/1.7.0/director/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the DirectorOnPrem char
 | `server.featureKialiDisable`                  | TBD                                           |      true                                 |
 | `server.analyticsGoogleCode`                  | TBD                                           |      none                                 |
 | `server.autoconnectLocalCluster`                | Autoconnect local cluster to openebs director |       true                                |
+| `server.maxMemberCountInOneProject`             | Maximum member count in one project. Some special values -  0 -> You can add as many members as you want. 1 -> You can not add any member(Disable teaming).         |       10                                |
 |                                                 |                                               |                                           |
 | `mysql.storageClass`                            | TBD                                           |      standard                             |
 |                                                 |                                               |                                           |

--- a/1.7.0/director/templates/maya-config.yaml
+++ b/1.7.0/director/templates/maya-config.yaml
@@ -79,4 +79,5 @@ data:
     api.auth.ad.user.object.class={{ .Values.server.adUserObjectClass }}
     api.auth.ad.connection.timeout={{ .Values.server.adConnectionTimeout }}
     api.auth.ad.group.object.class={{ .Values.server.adGroupObjectClass }}
+    server.projectmember.max.limit={{ .Values.server.maxMemberCountInOneProject }}
 ---

--- a/1.7.0/director/values.yaml
+++ b/1.7.0/director/values.yaml
@@ -15,6 +15,7 @@ server:
   apiAuthAccessMode: unrestricted
   serverDefaultAccessGrant: true
   apiUiEnabled: true
+  maxMemberCountInOneProject: 10
   setupName: directoronprem
   apiAuthExternalProviderEnabled: false
   apiAuthExternalProviderConfigured:


### PR DESCRIPTION
By default, you can add up to 10 members in your project.
This functionality is configurable. You can update the number in values.yaml.
There are some special values -
1. If you make it 0 then you can add as many members as you want.
2. If you make it 1 then you will not be able to add any member. This is one way to disable teaming.

NOTE - **This is a server level configuration not project level**.