### PR TITLE
Disable Google analytics for internal users

### DIFF
--- a/1.9.0/director/templates/maya-config.yaml
+++ b/1.9.0/director/templates/maya-config.yaml
@@ -57,6 +57,7 @@ data:
     feature.chatbot.disable={{ .Values.server.featureChatBotDisable }}
     slack.config.bot.client.id={{ .Values.server.slackConfigBotClientId }}
     slack.config.bot.client.secret={{ .Values.server.slackConfigBotClientSecret }}
+    feature.analytics.disable={{ .Values.server.featureAnalyticsDisable }}
     slack.config.bot.oauth.url=https://slack.com/oauth/authorize?client_id={{ .Values.server.slackConfigBotClientId }}&scope=bot\,incoming-webhook\,commands
     slack.notification.welcome.message={{ .Values.server.slackNotificationWelcomeMessage }}
     chatbot.alert.url={{ .Values.server.protocol }}://{{ .Values.server.url }}/chat-server/maya-events

--- a/1.9.0/director/values.yaml
+++ b/1.9.0/director/values.yaml
@@ -41,6 +41,8 @@ server:
   slackNotificationWelcomeMessage:
   featureKialiDisable: true
   analyticsGoogleCode:
+  ## featureAnalyticsDisable should be set to false in director-charts public repo
+  featureAnalyticsDisable: true
   autoconnectLocalCluster: true
   # The host URL of the AD server
   adHost:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Maya OpenEBS Director
 
-1.0 Plan
+1.x Plan
 
 https://docs.google.com/spreadsheets/d/12i1HKknQ_5vXd6bZst42AMyR_lTPdkkb4Svnr4fnxzo/edit?usp=sharing
 
+# Workflow for adding/updating helm charts for end users
 
-# Current status 
-Next milestone - RC1 (Delayed)
+TODO
+## Goals
+1. Define a well documented workflow so that a developer adds/modifies some flags in 1.n release, such that in 1.(n+1) release the dev/ops doesn't need to add the flag back again.
 
-# Blockers
- < TO DO >
+## Challenges
+1. The flags values might end up being different on [DC, mayadata-io/director-charts](https://github.com/mayadata-io/director-charts) & [DCI, mayadata-io/director-charts-internal](https://github.com/mayadata-io/director-charts-internal)
+
+## Differences b/w DC & DCI configuration
+1. The Google Analytics tracking is disabled on DCI but enabled on DC, see the `featureAnalyticsDisable` key in values.yaml
+
 
 ## Steps to bring up MOD on Packet
 ### Prerequisite


### PR DESCRIPTION
More info as to why this change is required:
1. It's confusing to keep track of Internal users at MayaData & external world from Google Analytics dashboard where user-identity information isn't available & isn't possible to get.
2. It's careless to assume that users from India is just us and stuff we run in 3rd floor lab.


URGENT: On a later stage, we need to keep track as to how we file update the file changes as code/configuration increases and as the differences between the internal-test/CI/internal-dogfooding/external-paid/external-evaluation Helm templates increase.