### PR TITLE
Added crm config to disable crm feature in E2E pipelines

### DIFF
--- a/1.12.0/director/templates/maya-config.yaml
+++ b/1.12.0/director/templates/maya-config.yaml
@@ -54,6 +54,7 @@ data:
     feature.cortexquerier.disable=true
     feature.litmus.disable=true
     feature.zendesk.disable=true
+    feature.crm.disable=true
     feature.chatbot.disable={{ .Values.server.featureChatBotDisable }}
     slack.config.bot.client.id={{ .Values.server.slackConfigBotClientId }}
     slack.config.bot.client.secret={{ .Values.server.slackConfigBotClientSecret }}


### PR DESCRIPTION
Signed-off-by: Sahil Raja <sahil.raja@mayadata.io>

- Added ```feature.crm.disable=true``` to disable crm features in E2E pipelines.